### PR TITLE
Fix API URL selection by environment

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -2,8 +2,11 @@
 import axios from 'axios';
 
 const API = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:5000/api',
-  // baseURL: 'http://localhost:5000/api',
+  baseURL:
+    process.env.REACT_APP_API_URL ||
+    (process.env.NODE_ENV === 'production'
+      ? 'https://fort-custer-api.up.railway.app/api'
+      : 'http://localhost:5000/api'),
 });
 
 API.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- set API base URL based on `NODE_ENV`

## Testing
- `npm install`
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68414bed256c832f8fe33fb92775b09c