### PR TITLE
Improve prize reveal flow

### DIFF
--- a/src/css/ResultsPage.css
+++ b/src/css/ResultsPage.css
@@ -1,0 +1,37 @@
+.crate {
+  width: 200px;
+  height: 200px;
+  background-image: url('/images/crate.png');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  cursor: pointer;
+  animation: crate-idle 2s ease-in-out infinite;
+}
+
+@keyframes crate-idle {
+  0%, 100% { transform: translateY(0) rotate(0); }
+  25% { transform: translateY(-4px) rotate(-3deg); }
+  50% { transform: translateY(0) rotate(0); }
+  75% { transform: translateY(-2px) rotate(2deg); }
+}
+
+.crate.opening {
+  animation: crate-open 0.6s forwards;
+}
+
+@keyframes crate-open {
+  0% { transform: scale(1) rotate(0); opacity: 1; }
+  25% { transform: scale(1.1) rotate(-5deg); opacity: 1; }
+  50% { transform: scale(0.9) rotate(5deg); opacity: 1; }
+  100% { transform: scale(2) rotate(0); opacity: 0; }
+}
+
+.reveal {
+  animation: reward-reveal 0.6s ease-out;
+}
+
+@keyframes reward-reveal {
+  from { transform: scale(0.5); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavBar from '../components/NavBar';
+import '../css/ResultsPage.css';
 
 export default function ResultsPage() {
   const [time, setTime] = useState(null);
   const [reward, setReward] = useState(null);
   const [revealed, setRevealed] = useState(false);
+  const [opening, setOpening] = useState(false);
   const navigate = useNavigate();
 
   // On mount, load lastTime/reward and ensure selectedMazeDate is set
@@ -48,6 +50,7 @@ export default function ResultsPage() {
   // Only playable if nextDate <= todayUTC
   const nextPlayable = nextDate <= todayUTC;
 
+  const showActions = reward ? revealed : true;
   const actionsDisabled = reward && !revealed;
 
   return (
@@ -83,6 +86,7 @@ export default function ResultsPage() {
                 <img
                   src={`/images/${reward.image}`}
                   alt={reward.name}
+                  className="reveal"
                   style={{ width: 200, height: 200, objectFit: 'contain' }}
                 />
                 <span style={{ fontSize: '1.5rem', marginTop: 8 }}>
@@ -91,16 +95,15 @@ export default function ResultsPage() {
               </>
             ) : (
               <div
-                onClick={() => setRevealed(true)}
-                style={{
-                  width: 200,
-                  height: 200,
-                  backgroundImage: 'url(/images/crate.png)',
-                  backgroundSize: 'contain',
-                  backgroundRepeat: 'no-repeat',
-                  backgroundPosition: 'center',
-                  cursor: 'pointer'
+                onClick={() => {
+                  if (opening) return;
+                  setOpening(true);
+                  setTimeout(() => {
+                    setRevealed(true);
+                    setOpening(false);
+                  }, 600);
                 }}
+                className={`crate${opening ? ' opening' : ''}`}
               />
             )}
           </div>
@@ -111,52 +114,56 @@ export default function ResultsPage() {
         </p>
       )}
 
-      {/* Replay always available */}
-      <button
-        onClick={() => navigate('/maze')}
-        disabled={actionsDisabled}
-        style={{
-          backgroundColor: actionsDisabled ? '#aaa' : '#00aef0',
-          color: '#fff',
-          fontSize: '1.2rem',
-          fontWeight: 'bold',
-          padding: '1rem',
-          width: '100%',
-          border: '2px solid #000',
-          marginTop: '2rem',
-          boxShadow: actionsDisabled ? 'none' : '4px 4px 0 #000',
-          cursor: actionsDisabled ? 'not-allowed' : 'pointer',
-        }}
-      >
-        Replay Maze
-      </button>
+      {showActions && (
+        <>
+          {/* Replay always available */}
+          <button
+            onClick={() => navigate('/maze')}
+            disabled={actionsDisabled}
+            style={{
+              backgroundColor: actionsDisabled ? '#aaa' : '#00aef0',
+              color: '#fff',
+              fontSize: '1.2rem',
+              fontWeight: 'bold',
+              padding: '1rem',
+              width: '100%',
+              border: '2px solid #000',
+              marginTop: '2rem',
+              boxShadow: actionsDisabled ? 'none' : '4px 4px 0 #000',
+              cursor: actionsDisabled ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Replay Maze
+          </button>
 
-      {/* Next Maze (disabled if tomorrow is not yet unlocked) */}
-      <button
-        onClick={() => {
-          if (!nextPlayable || actionsDisabled) return;
-          localStorage.setItem('selectedMazeDate', nextDate);
-          navigate('/maze');
-        }}
-        disabled={!nextPlayable || actionsDisabled}
-        style={{
-          backgroundColor:
-            !nextPlayable || actionsDisabled ? '#aaa' : '#4CAF50',
-          color: '#fff',
-          fontSize: '1.2rem',
-          fontWeight: 'bold',
-          padding: '1rem',
-          width: '100%',
-          border: '2px solid #000',
-          marginTop: '1rem',
-          boxShadow:
-            !nextPlayable || actionsDisabled ? 'none' : '4px 4px 0 #000',
-          cursor:
-            !nextPlayable || actionsDisabled ? 'not-allowed' : 'pointer',
-        }}
-      >
-        {nextPlayable ? 'Next Maze' : 'Next Unavailable'}
-      </button>
+          {/* Next Maze (disabled if tomorrow is not yet unlocked) */}
+          <button
+            onClick={() => {
+              if (!nextPlayable || actionsDisabled) return;
+              localStorage.setItem('selectedMazeDate', nextDate);
+              navigate('/maze');
+            }}
+            disabled={!nextPlayable || actionsDisabled}
+            style={{
+              backgroundColor:
+                !nextPlayable || actionsDisabled ? '#aaa' : '#4CAF50',
+              color: '#fff',
+              fontSize: '1.2rem',
+              fontWeight: 'bold',
+              padding: '1rem',
+              width: '100%',
+              border: '2px solid #000',
+              marginTop: '1rem',
+              boxShadow:
+                !nextPlayable || actionsDisabled ? 'none' : '4px 4px 0 #000',
+              cursor:
+                !nextPlayable || actionsDisabled ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {nextPlayable ? 'Next Maze' : 'Next Unavailable'}
+          </button>
+        </>
+      )}
 
       <NavBar />
     </div>


### PR DESCRIPTION
## Summary
- hide navigation actions until prize reveal
- add idle shake animation to prize crate
- animate reward reveal

## Testing
- `npm test --silent` *(fails: Test Suites: 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684263b2d69c832f8da3389991998ba8