### PR TITLE
Add fire hint bubble

### DIFF
--- a/src/css/MazePage.css
+++ b/src/css/MazePage.css
@@ -364,3 +364,12 @@ html, body {
   font-size: 1.25rem;
 }
 
+.thought-bubble {
+  position: absolute;
+  top: -1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: none;
+  font-size: 1.25rem;
+}
+


### PR DESCRIPTION
## Summary
- nudge players about fire extinguisher with a thought bubble

## Testing
- `npm test --silent` *(fails: No tests found / cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_684266449488832faee69bf1448bd33c