### PR TITLE
Fix crate image display on results page

### DIFF
--- a/src/css/ResultsPage.css
+++ b/src/css/ResultsPage.css
@@ -1,9 +1,6 @@
 .crate {
   width: 200px;
   height: 200px;
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
   cursor: pointer;
   animation: crate-idle 2s ease-in-out infinite;
 }

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -94,7 +94,9 @@ export default function ResultsPage() {
                 </span>
               </>
             ) : (
-              <div
+              <img
+                src="/images/crate.png"
+                alt="crate"
                 onClick={() => {
                   if (opening) return;
                   setOpening(true);


### PR DESCRIPTION
## Summary
- render crate image directly in ResultsPage component
- remove background-image from CSS so the crate uses an <img> instead

## Testing
- `npm test --silent --prefix .` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842687e8e88832fabda4abf5dc20bce