### PR TITLE
Fix category button cut off

### DIFF
--- a/src/pages/CollectionPage.js
+++ b/src/pages/CollectionPage.js
@@ -76,13 +76,14 @@ const pagedItems = filteredItems.slice(
       </h2>
 
       <div
-        style={{
-          display: 'flex',
-          overflowX: 'auto',
-          gap: '0.5rem',
-          padding: '0.5rem 0',
-          justifyContent: 'center',
-        }}
+          style={{
+            display: 'flex',
+            overflowX: 'auto',
+            gap: '0.5rem',
+            padding: '0.5rem',
+            justifyContent: 'center',
+            scrollPadding: '0.5rem',
+          }}
       >
         {categories.map((cat) => (
           <button


### PR DESCRIPTION
## Summary
- adjust category button row padding to prevent clipping

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684271d9b02c832f815fef69a060c03f