### PR TITLE
Adjust thought bubble size

### DIFF
--- a/src/css/MazePage.css
+++ b/src/css/MazePage.css
@@ -370,9 +370,9 @@ html, body {
   left: 50%;
   transform: translateX(-50%);
   pointer-events: none;
-  font-size: 1.25rem;
-  width: 1.6em;
-  height: 1.6em;
+  font-size: 1.5rem;
+  width: 2.4em;
+  height: 2.4em;
 }
 
 .thought-bubble::before {
@@ -390,6 +390,6 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.8em;
+  font-size: 1.2em;
 }
 


### PR DESCRIPTION
## Summary
- enlarge the thought bubble in the maze HUD so it's easier to see

## Testing
- `npm test --silent --runTestsByPath src/App.test.js` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842724b37ec832f98b0a1c7ca86df17