### PR TITLE
Fix horizontal scroll for inventory categories

### DIFF
--- a/src/pages/CollectionPage.js
+++ b/src/pages/CollectionPage.js
@@ -79,10 +79,12 @@ const pagedItems = filteredItems.slice(
           style={{
             display: 'flex',
             overflowX: 'auto',
+            flexWrap: 'nowrap',
             gap: '0.5rem',
             padding: '0.5rem',
-            justifyContent: 'center',
+            justifyContent: 'flex-start',
             scrollPadding: '0.5rem',
+            WebkitOverflowScrolling: 'touch',
           }}
       >
         {categories.map((cat) => (


### PR DESCRIPTION
## Summary
- ensure category buttons in Field Kit page have horizontal scrolling

## Testing
- `npm test -- -u` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684272e2fbe4832f8fe02be50440f1a2