### PR TITLE
Fix thought bubble placement

### DIFF
--- a/src/css/MazePage.css
+++ b/src/css/MazePage.css
@@ -366,11 +366,12 @@ html, body {
 
 .thought-bubble {
   position: absolute;
-  /* place bubble well above the player so it doesn't overlap */
-  top: -2.5rem;
+  /* position bubble so its bottom sits just above the player */
+  bottom: calc(100% + 0.25rem);
   left: 50%;
   transform: translateX(-50%);
   pointer-events: none;
+  z-index: 3000;
   /* enlarge the bubble so the emoji inside has some padding */
   font-size: 2rem;
   width: 3em;


### PR DESCRIPTION
## Summary
- move the thought bubble just above the player
- raise bubble z-index so it renders above fog of war

## Testing
- `npm install`
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684275266504832fb4311f68c584e309