### PR TITLE
Fix personal best notification

### DIFF
--- a/src/pages/MazePage.js
+++ b/src/pages/MazePage.js
@@ -160,10 +160,18 @@ const MazePage = () => {
 
       const key = selectedDate;
       const bestTimes = JSON.parse(localStorage.getItem('bestTimes') || '{}');
-      const best = bestTimes[key];
-      if (!best || time < best) {
+      const prevBest = bestTimes[key];
+      let isNewRecord = false;
+
+      if (prevBest === undefined || time < prevBest) {
+        if (prevBest !== undefined && time < prevBest) {
+          isNewRecord = true;
+        }
         bestTimes[key] = time;
         localStorage.setItem('bestTimes', JSON.stringify(bestTimes));
+      }
+
+      if (isNewRecord) {
         localStorage.setItem('lastNewRecord', 'true');
       } else {
         localStorage.removeItem('lastNewRecord');

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -80,7 +80,7 @@ export default function ResultsPage() {
       )}
       {newRecord && (
         <p className="new-record" style={{ fontSize: '1.25rem', margin: '0.5rem 0' }}>
-          🎉 New fastest time! 🎉
+          🎉 New personal best time! 🎉
         </p>
       )}
 


### PR DESCRIPTION
## Summary
- show "New personal best time" instead of "new fastest time"
- only mark a new record if a previous time exists

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684282954c70832fac5b8227d92bce0c